### PR TITLE
fix/custom fields from request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.6
+
+- fix: change to woocommerce_process_shop_order_meta hook
+- chore: remove redundant hack that prevented multiple requests from being sent
+- fix: pick order meta data from request instead of database to make sure we get the values that are to be updated.
+
 ## 1.4.5
 
 - Fix: Make sure WordPress is installed with fixed version in Docker setup

--- a/classes/class-ledyer-om-main.php
+++ b/classes/class-ledyer-om-main.php
@@ -18,7 +18,7 @@ class Ledyer_Order_Management_For_WooCommerce {
 	public $parentSettings;
 	public $api;
 
-	const VERSION = '1.4.5';
+	const VERSION = '1.4.6';
 	const SLUG = 'ledyer-order-management-for-woocommerce';
 	const SETTINGS = 'ledyer_order_management_for_woocommerce_settings';
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
         define( 'WP_ENVIRONMENT_TYPE', 'local' );
     volumes:
       - "./:/var/www/html/wp-content/plugins/ledyer-order-management-for-woocommerce"
-      - "../ledyer-checkout-for-woocommerce/:/var/www/html/wp-content/plugins/ledyer-checkout-for-woocommerce"
+      # - "../ledyer-checkout-for-woocommerce/:/var/www/html/wp-content/plugins/ledyer-checkout-for-woocommerce"
       - wpdata:/var/www/html
 
   wordpress-cron:
@@ -83,7 +83,7 @@ services:
       '
     volumes:
       - "./:/var/www/html/wp-content/plugins/ledyer-order-management-for-woocommerce"
-      - "../ledyer-checkout-for-woocommerce/:/var/www/html/wp-content/plugins/ledyer-checkout-for-woocommerce"
+      # - "../ledyer-checkout-for-woocommerce/:/var/www/html/wp-content/plugins/ledyer-checkout-for-woocommerce"
       - wpdata:/var/www/html
 
 volumes:

--- a/ledyer-order-management-for-woocommerce.php
+++ b/ledyer-order-management-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Ledyer Order Management for WooCommerce.
  * Author: Ledyer AB
  * Author URI: https://www.ledyer.com
- * Version: 1.4.5
+ * Version: 1.4.6
  * Text Domain: ledyer-order-management-for-woocommerce
  * Domain Path: /languages
  *

--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,6 @@ Tested up to: 6.2
 Requires PHP: 7.0
 WC requires at least: 4.0.0
 WC tested up to: 6.9.3
-Stable tag: 1.4.5
+Stable tag: 1.4.6
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
- fix: remove validation and fix wordpress version in setup
- fix: pick order meta data from request instead of database, to make sure we get the values that are to be updated.
- fix: change to woocommerce_process_shop_order_meta hook and remove redundant hack that prevented multiple requests from being sent
- chore: bump version
