### PR TITLE
Fix the logic of the lom_is_order_editable check

### DIFF
--- a/includes/lom-edit.php
+++ b/includes/lom-edit.php
@@ -66,7 +66,7 @@ function lom_allow_editing( $order ) {
 }
 
 function lom_is_order_editable( $ledyer_order ) {
-	return count( $ledyer_order['status'] ) == 1 && in_array( LedyerOmOrderStatus::uncaptured, $ledyer_order['status'] );
+	return in_array( LedyerOmOrderStatus::uncaptured, $ledyer_order['status'] );
 }
 
 function lom_process_order_sync( $order, $api, $ledyer_order_id ) {


### PR DESCRIPTION
Fix the logic of the lom_is_order_editable check, since the order statuses from Ledyer seldomly seems to be returned as one array item even if uncaptured.