### PR TITLE
Add integration capture API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ wordpress-cli:
 ## Debugging
 
 In VS code, install xdebug and optionally a PHP intellisense extension. Then just click Run and debug
+
+## Capture API for WordPress integrations
+
+Trusted server-side plugins can request a full capture using the WooCommerce order ID:
+
+```php
+$result = ledyer_om_capture_order( $order_id );
+
+if ( is_wp_error( $result ) ) {
+	// Handle $result->get_error_message().
+} else {
+	// $result['result'] is "captured" or "already_captured".
+}
+```
+
+The function bypasses the automatic capture setting and local WooCommerce paid/ready state. It captures only when Ledyer reports `paymentConfirmed`; other statuses return `WP_Error`. Call it after `plugins_loaded` and guard with `function_exists( 'ledyer_om_capture_order' )`.

--- a/includes/lom-capture.php
+++ b/includes/lom-capture.php
@@ -3,6 +3,67 @@
 \defined( 'ABSPATH' ) || die();
 
 /**
+ * Captures a Ledyer order for a trusted WordPress integration.
+ *
+ * @param int $order_id WooCommerce order ID.
+ * @return array|WP_Error Capture result or error.
+ */
+function ledyer_om_capture_order( $order_id ) {
+	$order = wc_get_order( $order_id );
+	if ( ! $order || ! lom_order_placed_with_ledyer( $order->get_payment_method() ) ) {
+		return new WP_Error( 'ledyer_invalid_order', 'The order is not a Ledyer order.' );
+	}
+
+	$ledyer_order_id = $order->get_meta( '_wc_ledyer_order_id', true );
+	if ( ! $ledyer_order_id ) {
+		return new WP_Error( 'ledyer_order_id_missing', 'The Ledyer order ID is missing.' );
+	}
+
+	$api            = ledyerOm()->api;
+	$payment_status = $api->get_payment_status( $ledyer_order_id );
+	if ( is_wp_error( $payment_status ) ) {
+		return $payment_status;
+	}
+
+	$status = $payment_status['status'] ?? LedyerOmPaymentStatus::unknown;
+	if ( LedyerOmPaymentStatus::orderCaptured === $status ) {
+		return array(
+			'result'         => 'already_captured',
+			'payment_status' => $payment_status,
+		);
+	}
+
+	if ( LedyerOmPaymentStatus::paymentConfirmed !== $status ) {
+		$message = sprintf( 'The Ledyer order cannot be captured because its payment status is "%s".', $status );
+		if ( ! empty( $payment_status['note'] ) ) {
+			$message .= ' ' . $payment_status['note'];
+		}
+		return new WP_Error( 'ledyer_capture_unavailable', $message, $payment_status );
+	}
+
+	$order_mapper = new \LedyerOm\OrderMapper( $order );
+	$response     = $api->capture_order( $ledyer_order_id, $order_mapper->woo_to_ledyer_capture_order_lines() );
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	$capture_id = $response['captured'][0]['ledgerId'] ?? '';
+	if ( ! $capture_id ) {
+		return new WP_Error( 'ledyer_invalid_capture_response', 'Ledyer returned no capture ID.', $response );
+	}
+
+	$order->add_order_note( 'Ledyer order captured. Capture ID: ' . $capture_id );
+	$order->update_meta_data( '_wc_ledyer_capture_id', $capture_id );
+	$order->save();
+
+	return array(
+		'result'       => 'captured',
+		'capture_id'   => $capture_id,
+		'ledyer_order' => $response,
+	);
+}
+
+/**
  * Captures a Ledyer order.
  *
  * @param int                      $order_id Order ID.

--- a/includes/lom-capture.php
+++ b/includes/lom-capture.php
@@ -41,26 +41,7 @@ function ledyer_om_capture_order( $order_id ) {
 		return new WP_Error( 'ledyer_capture_unavailable', $message, $payment_status );
 	}
 
-	$order_mapper = new \LedyerOm\OrderMapper( $order );
-	$response     = $api->capture_order( $ledyer_order_id, $order_mapper->woo_to_ledyer_capture_order_lines() );
-	if ( is_wp_error( $response ) ) {
-		return $response;
-	}
-
-	$capture_id = $response['captured'][0]['ledgerId'] ?? '';
-	if ( ! $capture_id ) {
-		return new WP_Error( 'ledyer_invalid_capture_response', 'Ledyer returned no capture ID.', $response );
-	}
-
-	$order->add_order_note( 'Ledyer order captured. Capture ID: ' . $capture_id );
-	$order->update_meta_data( '_wc_ledyer_capture_id', $capture_id );
-	$order->save();
-
-	return array(
-		'result'       => 'captured',
-		'capture_id'   => $capture_id,
-		'ledyer_order' => $response,
-	);
+	return lom_attempt_ledyer_order_capture( $order, $ledyer_order_id, $api );
 }
 
 /**
@@ -157,17 +138,9 @@ function lom_capture_ledyer_order( $order_id, $api, $action = false ) {
 		return;
 	}
 
-	$orderMapper = new \LedyerOm\OrderMapper( $order );
-	$data        = $orderMapper->woo_to_ledyer_capture_order_lines();
-	$response    = $api->capture_order( $ledyer_order_id, $data );
+	$response = lom_attempt_ledyer_order_capture( $order, $ledyer_order_id, $api );
 
 	if ( ! is_wp_error( $response ) ) {
-		$first_captured = lom_get_first_captured( $response );
-		$capture_id     = $first_captured['ledgerId'];
-
-		$order->add_order_note( 'Ledyer order captured. Capture amount: ' . $order->get_formatted_order_total( '', false ) . '. Capture ID: ' . $capture_id );
-		$order->update_meta_data( '_wc_ledyer_capture_id', $capture_id );
-		$order->save();
 		return;
 	}
 
@@ -178,6 +151,39 @@ function lom_capture_ledyer_order( $order_id, $api, $action = false ) {
 		$order->add_order_note( $errmsg );
 	}
 	$order->save();
+}
+
+/**
+ * Performs a full Ledyer capture and saves its capture ID.
+ *
+ * @param WC_Order $order WooCommerce order.
+ * @param string   $ledyer_order_id Ledyer order ID.
+ * @param object   $api Ledyer Order Management API instance.
+ * @return array|WP_Error Capture result or error.
+ */
+function lom_attempt_ledyer_order_capture( $order, $ledyer_order_id, $api ) {
+	$order_mapper = new \LedyerOm\OrderMapper( $order );
+	$data         = $order_mapper->woo_to_ledyer_capture_order_lines();
+	$response     = $api->capture_order( $ledyer_order_id, $data );
+
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	$capture_id = $response['captured'][0]['ledgerId'] ?? '';
+	if ( ! $capture_id ) {
+		return new WP_Error( 'ledyer_invalid_capture_response', 'Ledyer returned no capture ID.', $response );
+	}
+
+	$order->add_order_note( 'Ledyer order captured. Capture amount: ' . $order->get_formatted_order_total( '', false ) . '. Capture ID: ' . $capture_id );
+	$order->update_meta_data( '_wc_ledyer_capture_id', $capture_id );
+	$order->save();
+
+	return array(
+		'result'       => 'captured',
+		'capture_id'   => $capture_id,
+		'ledyer_order' => $response,
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a synchronous capture function for trusted WordPress integrations
- use Ledyer payment status as the capture readiness source
- return explicit captured, already-captured, or WP_Error outcomes
- document the integration entry point

## Verification
- `php -l includes/lom-capture.php`
- `git diff --check`
- focused code review